### PR TITLE
Fix for movies without ratings

### DIFF
--- a/letterboxd-feed-wp.py
+++ b/letterboxd-feed-wp.py
@@ -297,6 +297,12 @@ def fetch_lb_rss(user):
                 timestamp = time.strptime(movie.letterboxd_watcheddate, "%Y-%m-%d")
             else:
                 timestamp = movie.published_parsed
+                
+            # Handle null ratings
+            if movie.letterboxd_memberrating:
+                rating = movie.letterboxd_memberrating
+            else:
+                rating = None
 
             clean_review = clean_rss_review_html(movie.summary, spoiler_flag)
 
@@ -308,7 +314,7 @@ def fetch_lb_rss(user):
                     "timestamp": timestamp,
                     "review": str(clean_review),
                     "year": movie.letterboxd_filmyear,
-                    "rating": movie.letterboxd_memberrating,
+                    "rating": rating,
                     "spoiler": spoiler_flag,
                 }
             )


### PR DESCRIPTION
Fixes #33 (movies without a rating break fetchrss).

It's not a problem for fetchcsv, since if there's not a rating there, the CSV library will just fork over a null for the rating. However, the property won't exist in the RSS feed if you didn't rate the movie.

At some point possibly I'll build a test feed; the movie that triggered this problem for me is over 20 entries back in my queue so I'm not 100% sure of the fix. However, it's still processing movies with ratings fine and the code fix was really simple.
